### PR TITLE
Correct commands in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Templates to quickly bootstrap a repo with `nix flakes`.
 
 To get started in a existing repo:
 
-`nix flakes init --template ulrikstrid/nix-templates#ocaml`
+`nix flake init --template github:ulrikstrid/nix-templates#ocaml`
 
 To bootstrap a new repo run:
 
-`nix flakes new ulrikstrid/nix-templates#ocaml`
+`nix flake new github:ulrikstrid/nix-templates#ocaml`
 
 We're using yhe OCaml overlays [repo by @anmonteiro](https://github.com/anmonteiro/nix-overlays) to get some of the latest and greatest that hasn't yet made it to `nixpkgs`. There is also excellent support for static compilation.
 


### PR DESCRIPTION
The commands in the README seem to have some typos.